### PR TITLE
Feature/bruce 5273 remove gauva from aem design core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 
 on:
   push:
@@ -6,165 +6,36 @@ on:
       - master
       - develop
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
 
-    strategy:
-      max-parallel: 4
-      matrix:
-        java-version: [ 8 ]
-        python-version: [ 3.6 ]
-
-    env:
-      DOCKER_IMAGE: "aemdesign/centos-java-buildpack"
-      SONAR_ORGANISATION: "aemdesign-github"
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      SONAR_URL: "https://sonarcloud.io"
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      SONATYPE_USERNAME: "aemdesign"
-      GITHUB_USER: aemdesign
-      GITHUB_EMAIL: ${{ secrets.GITHUB_EMAIL }}
-      GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
-      GITHUB_TOKEN_ADMIN: ${{ secrets.GITHUB_TOKEN_ADMIN }}
-      AEM_NAME: ${{ secrets.AEM_NAME }}
-      AEM_KEY: ${{ secrets.AEM_KEY }}
-      GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
-      GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      GPG_EXECUTABLE: gpg
-      GPG_PRESET_EXECUTABLE: /usr/lib/gnupg/gpg-preset-passphrase
-      GPG_PUBID: "50A036956AAC64C13EF47B10D1E96A30ECFC7DFF"
-      GPG_PUBID_KEYGRIP: "020E615868703482DC2CD110B98D2702B6ABF89C"
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          submodules: true
-          lfs: true
+          # full history required: git-commit-id-plugin derives the project
+          # version from the nearest git tag + commit count
+          fetch-depth: 0
 
-      - name: set up jdk ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
+      - name: set up java 8
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: '8'
+          distribution: temurin
+          cache: maven
+          # configures a 'github' server entry in settings.xml for deploy
+          registry-url: https://maven.pkg.github.com
 
-      - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: build and test
+        run: mvn package -B
 
-      - name: get release notes
-        id: config
+      - name: deploy to github packages
+        if: github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source <(curl -sL https://github.com/aem-design/aemdesign-docker/releases/latest/download/github_get_version.sh)
-
-      - name: release notes
-        run: |
-          echo "${{ steps.config.outputs.GIT_RELEASE_NOTES }}"
-          echo CURRENT_VERSION="${{ steps.config.outputs.CURRENT_VERSION }}"
-
-      - name: set eval variables
-        run: |
-          echo "DOCKER_COMMAND=docker run --user $(id -u):$(id -g) -v ${GITHUB_WORKSPACE}:/build ${DOCKER_IMAGE}" >> $GITHUB_ENV
-          $DOCKER_COMMAND java -version
-          $DOCKER_COMMAND node -v
-          git config --global user.email "${GITHUB_EMAIL}"
-          git config --global user.name "${GITHUB_USERNAME}"
-
-      - name: setup gpg
-        run: |
-          source <(curl -sL https://github.com/aem-design/aemdesign-docker/releases/latest/download/setup-gpg.sh)
-
-      - name: cache sonarcloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: cache maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: mvn package
-        run: $DOCKER_COMMAND mvn package -B -Dmaven.repo.local=./build/.m2/repository
-
-      # SonarQube for master
-      #- name: docker - sonar qube on master
-      #  if: github.ref == 'refs/heads/master'
-      #  run: mvn sonar:sonar -q "-Dsonar.branch.name=${GITHUB_REF}" "-Dsonar.host.url=${SONAR_URL}" "-Dsonar.login=${SONAR_TOKEN}" "-Dsonar.organization=${SONAR_ORGANISATION}"
-
-      # SonarQube for branches
-      #- name: docker - sonar qube on branches
-      #  if: github.ref != 'refs/heads/master'
-      #  run: mvn sonar:sonar -q "-Dsonar.branch.name=${GITHUB_REF}" "-Dsonar.branch.target=master" "-Dsonar.host.url=${SONAR_URL}" "-Dsonar.login=${SONAR_TOKEN}" "-Dsonar.organization=${SONAR_ORGANISATION}"
-
-      - name: run unit tests with coverage reports
-        run: mvn test -q && bash <(curl -s https://codecov.io/bash)
-
-      - name: deploy to maven cental
-        if: github.ref == 'refs/heads/master'
-        run: $DOCKER_COMMAND echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import && echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust && mvn deploy --settings default.xml -B -P release
-
-      - name: create release ${{ env.GITHUB_TAG }}
-        if: github.ref == 'refs/heads/master'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.config.outputs.CURRENT_VERSION }}
-          release_name: ${{ steps.config.outputs.CURRENT_VERSION }}
-          body: ${{ steps.config.outputs.GIT_RELEASE_NOTES }}
-          draft: false
-          prerelease: false
-
-      - name: upload release asset - aemdesign-aem-core-deploy-${{ env.GITHUB_TAG }}.zip
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ format('./aemdesign-aem-{0}/target/aemdesign-aem-{0}-{1}.zip', 'core-deploy', env.GITHUB_TAG) }}
-          asset_name: ${{ format('aemdesign-aem-{0}-{1}.zip', 'core-deploy', env.GITHUB_TAG) }}
-          asset_content_type: application/zip
-
-      - name: upload release asset - aemdesign-aem-services-${{ env.GITHUB_TAG }}.zip
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ format('./aemdesign-aem-{0}/target/aemdesign-aem-{0}-{1}.jar', 'services', env.GITHUB_TAG) }}
-          asset_name: ${{ format('aemdesign-aem-{0}-{1}.jar', 'services', env.GITHUB_TAG) }}
-          asset_content_type: application/java-archive
-
-      - name: upload release asset - aemdesign-aem-author-${{ env.GITHUB_TAG }}.zip
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ format('./aemdesign-aem-{0}/target/aemdesign-aem-{0}-{1}.zip', 'author', env.GITHUB_TAG) }}
-          asset_name: ${{ format('aemdesign-aem-{0}-{1}.zip', 'author', env.GITHUB_TAG) }}
-          asset_content_type: application/zip
-
-      - name: upload release asset - aemdesign-aem-common-${{ env.GITHUB_TAG }}.zip
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ format('./aemdesign-aem-{0}/target/aemdesign-aem-{0}-{1}.zip', 'common', env.GITHUB_TAG) }}
-          asset_name: ${{ format('aemdesign-aem-{0}-{1}.zip', 'common', env.GITHUB_TAG) }}
-          asset_content_type: application/zip
+          mvn deploy -B -DskipTests \
+            -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}

--- a/aemdesign-aem-author/pom.xml
+++ b/aemdesign-aem-author/pom.xml
@@ -6,9 +6,9 @@
     <!-- P A R E N T    P R O J E C T    D E S C R I P T I O N                  -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>design.aem</groupId>
+        <groupId>au.com.aligent</groupId>
         <artifactId>aemdesign-aem-core</artifactId>
-        <version>2.1.306</version>
+        <version>.</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,7 +17,7 @@
     <!-- ====================================================================== -->
 
     <artifactId>aemdesign-aem-author</artifactId>
-    <version>2.1.306</version>
+    <version>.</version>
     <packaging>content-package</packaging>
     <name>AEM Design - Core - AEM Author UI Updates</name>
     <description>AEM.Design extensions and libraries that enhance the default authoring UI</description>
@@ -35,27 +35,19 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/aem-design/aemdesign-aem-core.git</connection>
-        <url>https://github.com/aem-design/aemdesign-aem-core</url>
+        <connection>scm:git:https://github.com/MMAL/aemdesign-aem-core.git</connection>
+        <url>https://github.com/MMAL/aemdesign-aem-core</url>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/aem-design/aemdesign-aem-core/issues</url>
+        <url>https://github.com/MMAL/aemdesign-aem-core/issues</url>
     </issueManagement>
 
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/aem-design/aemdesign-aem-core/wiki</url>
-        </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/MMAL/aemdesign-aem-core</url>
         </repository>
     </distributionManagement>
 

--- a/aemdesign-aem-common/pom.xml
+++ b/aemdesign-aem-common/pom.xml
@@ -6,9 +6,9 @@
     <!-- P A R E N T    P R O J E C T    D E S C R I P T I O N                  -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>design.aem</groupId>
+        <groupId>au.com.aligent</groupId>
         <artifactId>aemdesign-aem-core</artifactId>
-        <version>2.1.306</version>
+        <version>.</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,7 +17,7 @@
     <!-- ====================================================================== -->
 
     <artifactId>aemdesign-aem-common</artifactId>
-    <version>2.1.306</version>
+    <version>.</version>
     <packaging>content-package</packaging>
     <name>AEM Design - Core - AEM Common</name>
     <description>AEM.Design components and base templates</description>
@@ -35,27 +35,19 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/aem-design/aemdesign-aem-core.git</connection>
-        <url>https://github.com/aem-design/aemdesign-aem-core</url>
+        <connection>scm:git:https://github.com/MMAL/aemdesign-aem-core.git</connection>
+        <url>https://github.com/MMAL/aemdesign-aem-core</url>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/aem-design/aemdesign-aem-core/issues</url>
+        <url>https://github.com/MMAL/aemdesign-aem-core/issues</url>
     </issueManagement>
 
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/aem-design/aemdesign-aem-core/wiki</url>
-        </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/MMAL/aemdesign-aem-core</url>
         </repository>
     </distributionManagement>
 

--- a/aemdesign-aem-core-deploy/pom.xml
+++ b/aemdesign-aem-core-deploy/pom.xml
@@ -6,9 +6,9 @@
     <!-- P A R E N T    P R O J E C T    D E S C R I P T I O N                  -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>design.aem</groupId>
+        <groupId>au.com.aligent</groupId>
         <artifactId>aemdesign-aem-core</artifactId>
-        <version>2.1.306</version>
+        <version>.</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -20,7 +20,7 @@
     <packaging>content-package</packaging>
     <name>AEM Design - Core - Deployment Package</name>
     <description>AEM.Design deployment package for all packages</description>
-    <version>2.1.306</version>
+    <version>.</version>
     <url>https://aem.design</url>
 
     <developers>
@@ -35,27 +35,19 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/aem-design/aemdesign-aem-core.git</connection>
-        <url>https://github.com/aem-design/aemdesign-aem-core</url>
+        <connection>scm:git:https://github.com/MMAL/aemdesign-aem-core.git</connection>
+        <url>https://github.com/MMAL/aemdesign-aem-core</url>
     </scm>
 
     <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/aem-design/aemdesign-aem-core/issues</url>
+        <system>GitHub</system>
+        <url>https://github.com/MMAL/aemdesign-aem-core/issues</url>
     </issueManagement>
 
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/aem-design/aemdesign-aem-core/wiki</url>
-        </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/MMAL/aemdesign-aem-core</url>
         </repository>
     </distributionManagement>
 

--- a/aemdesign-aem-services/pom.xml
+++ b/aemdesign-aem-services/pom.xml
@@ -7,9 +7,9 @@
     <!-- P A R E N T    P R O J E C T    D E S C R I P T I O N                  -->
     <!-- ====================================================================== -->
     <parent>
-        <groupId>design.aem</groupId>
+        <groupId>au.com.aligent</groupId>
         <artifactId>aemdesign-aem-core</artifactId>
-        <version>2.1.306</version>
+        <version>.</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
     <!-- ====================================================================== -->
 
     <artifactId>aemdesign-aem-services</artifactId>
-    <version>2.1.306</version>
+    <version>.</version>
     <packaging>jar</packaging>
     <name>AEM Design - Core - AEM Services</name>
     <description>Project for all AEM and OSGI Services</description>
@@ -46,27 +46,19 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/aem-design/aemdesign-aem-core.git</connection>
-        <url>https://github.com/aem-design/aemdesign-aem-core</url>
+        <connection>scm:git:https://github.com/MMAL/aemdesign-aem-core.git</connection>
+        <url>https://github.com/MMAL/aemdesign-aem-core</url>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/aem-design/aemdesign-aem-core/issues</url>
+        <url>https://github.com/MMAL/aemdesign-aem-core/issues</url>
     </issueManagement>
 
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/aem-design/aemdesign-aem-core/wiki</url>
-        </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/MMAL/aemdesign-aem-core</url>
         </repository>
     </distributionManagement>
 
@@ -206,6 +198,7 @@
                         <configuration>
                             <bnd><![CDATA[
 Bundle-SymbolicName: design.aem.aemdesign-aem-services
+Bundle-Version: 2.0.666
 Bundle-Category: design.aem
 Bundle-Description: ${project.description}
 Bundle-DocURL: https://aem.design

--- a/aemdesign-aem-services/src/main/java/design/aem/models/v2/details/GenericDetails.java
+++ b/aemdesign-aem-services/src/main/java/design/aem/models/v2/details/GenericDetails.java
@@ -3,7 +3,6 @@ package design.aem.models.v2.details;
 import com.day.cq.tagging.TagConstants;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.Page;
-import com.google.common.base.Throwables;
 import design.aem.components.ComponentProperties;
 import design.aem.models.BaseComponent;
 import design.aem.models.v2.content.ContentTemplate;
@@ -361,7 +360,7 @@ public class GenericDetails extends BaseComponent {
                             componentProperties.putAll(badgeConfig);
 
                         } catch (Exception ex) {
-                            LOGGER.error(Throwables.getStackTraceAsString(ex));
+                            LOGGER.error("Error processing <whatever context>", ex);
                         }
                     }
                 }

--- a/aemdesign-aem-services/src/main/java/design/aem/utils/components/ComponentsUtil.java
+++ b/aemdesign-aem-services/src/main/java/design/aem/utils/components/ComponentsUtil.java
@@ -18,7 +18,6 @@ import com.day.cq.wcm.api.policies.ContentPolicyManager;
 import com.day.cq.wcm.webservicesupport.Configuration;
 import com.day.cq.wcm.webservicesupport.ConfigurationConstants;
 import com.day.cq.wcm.webservicesupport.ConfigurationManager;
-import com.google.common.base.Throwables;
 import design.aem.components.AttrBuilder;
 import design.aem.components.ComponentField;
 import design.aem.components.ComponentProperties;
@@ -1744,7 +1743,7 @@ public class ComponentsUtil {
 
 
             } catch (Exception ex) {
-                LOGGER.error(Throwables.getStackTraceAsString(ex));
+                LOGGER.error("Error processing <whatever context>", ex);
             }
         } else {
             LOGGER.error("getCloudConfigProperty: could not get ContentAccess service.");
@@ -1936,7 +1935,7 @@ public class ComponentsUtil {
                     }
 
                 } catch (Exception ex) {
-                    LOGGER.error(Throwables.getStackTraceAsString(ex));
+                    LOGGER.error("Error processing <whatever context>", ex);
                 }
 
             } else {
@@ -2005,7 +2004,7 @@ public class ComponentsUtil {
                     }
 
                 } catch (Exception ex) {
-                    LOGGER.error(Throwables.getStackTraceAsString(ex));
+                    LOGGER.error("Error processing <whatever context>", ex);
                 }
 
             } else {

--- a/aemdesign-aem-services/src/main/java/design/aem/utils/components/ImagesUtil.java
+++ b/aemdesign-aem-services/src/main/java/design/aem/utils/components/ImagesUtil.java
@@ -12,8 +12,6 @@ import com.day.cq.dam.commons.util.DamUtil;
 import com.day.cq.tagging.Tag;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.foundation.Image;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import design.aem.components.ComponentProperties;
 import design.aem.services.ContentAccess;
 import design.aem.utils.WidthBasedRenditionComparator;
@@ -628,7 +626,8 @@ public class ImagesUtil {
      * @return matching rendition
      */
     public static com.adobe.granite.asset.api.Rendition getBestFitRendition(int width, com.adobe.granite.asset.api.Asset asset) {
-        List<com.adobe.granite.asset.api.Rendition> renditions = Lists.newArrayList(asset.listRenditions());
+        List<com.adobe.granite.asset.api.Rendition> renditions = new ArrayList<>();
+        asset.listRenditions().forEachRemaining(renditions::add);
         return getBestFitRendition(width, renditions, null);
     }
 
@@ -640,7 +639,8 @@ public class ImagesUtil {
      * @return matching rendition
      */
     public static com.adobe.granite.asset.api.Rendition getBestFitRendition(int width, com.adobe.granite.asset.api.Asset asset, String renditionPrefix) {
-        List<com.adobe.granite.asset.api.Rendition> renditions = Lists.newArrayList(asset.listRenditions());
+        List<com.adobe.granite.asset.api.Rendition> renditions = new ArrayList<>();
+        asset.listRenditions().forEachRemaining(renditions::add);
         return getBestFitRendition(width, renditions, renditionPrefix);
 
     }
@@ -903,7 +903,7 @@ public class ImagesUtil {
                     return imageProperties;
                 }
             } catch (Exception ex) {
-                LOGGER.error(Throwables.getStackTraceAsString(ex));
+                LOGGER.error("Error processing <whatever context>", ex);
             }
         } else {
             LOGGER.error("getBackgroundVideoRenditions: could not get ContentAccess service.");
@@ -1075,7 +1075,7 @@ public class ImagesUtil {
                 }
 
             } catch (Exception ex) {
-                LOGGER.error(Throwables.getStackTraceAsString(ex));
+                LOGGER.error("Error processing <whatever context>", ex);
             }
         } else {
             LOGGER.error("getResourceImageRenditions: could not get ContentAccess service.");

--- a/aemdesign-aem-services/src/main/java/design/aem/utils/components/TagUtil.java
+++ b/aemdesign-aem-services/src/main/java/design/aem/utils/components/TagUtil.java
@@ -74,7 +74,6 @@ public class TagUtil {
                 }
             } catch (Exception ex) {
                 LOGGER.error("getTagValueAsAdmin: {}", ex);
-                //out.write( Throwables.getStackTraceAsString(ex) );
             }
         } else {
             LOGGER.error("getTagValueAsAdmin: could not get ContentAccess service.");

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
     <!-- P A R E N T     P R O J E C T     D E S C R I P T I O N                -->
     <!-- ====================================================================== -->
 
-    <groupId>design.aem</groupId>
+    <groupId>au.com.aligent</groupId>
     <artifactId>aemdesign-aem-core</artifactId>
-    <version>2.1.306</version>
+    <version>.</version>
     <packaging>pom</packaging>
 
     <name>AEM Design - Core Project</name>
@@ -85,27 +85,19 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/aem-design/aemdesign-aem-core.git</connection>
-        <url>https://github.com/aem-design/aemdesign-aem-core</url>
+        <connection>scm:git:https://github.com/MMAL/aemdesign-aem-core.git</connection>
+        <url>https://github.com/MMAL/aemdesign-aem-core</url>
     </scm>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/aem-design/aemdesign-aem-core/issues</url>
+        <url>https://github.com/MMAL/aemdesign-aem-core/issues</url>
     </issueManagement>
 
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/aem-design/aemdesign-aem-core/wiki</url>
-        </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/MMAL/aemdesign-aem-core</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Remove Guava Dependancies from AEM Design Core
 - Remove  com.google.common.base.Throwables import and replace it with alternative logging that does not require it.
 - Remove com.google.common.collect.Lists and replace it with alternative function.

Repackage (as this is a forked version) update dep links to refer to this GH repo.

Replace GHA to one that builds and packages the module on GH